### PR TITLE
Removes the logging number of rows affected for UpdateASingleRow func

### DIFF
--- a/utils/check_effected_rows_result.go
+++ b/utils/check_effected_rows_result.go
@@ -19,6 +19,6 @@ func GetRowsAffected(results sql.Result, targetNumRowsAffected int64) error {
 		log.Printf("ERROR: %s", sqlErr)
 		return sqlErr
 	}
-	log.Printf("Rows affected: %v / %v", rowsAffected, targetNumRowsAffected)
+
 	return nil
 }


### PR DESCRIPTION
Removes the logging for checking the updated rows number match since the only func using it is a single row updater